### PR TITLE
feat: add traffic using script

### DIFF
--- a/generate_traffic.sh
+++ b/generate_traffic.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# --------------------------------------------------------
+# Generates sample HTTP traffic against the Bookstore API
+# to produce trace data for OpenTelemetry and SigNoz.
+#
+# This script performs create, read, update, delete (CRUD)
+# operations in a loop to simulate real usage patterns.
+# --------------------------------------------------------
+
+API_URL="http://localhost:8090"
+ITERATIONS=60
+SLEEP_INTERVAL=0.5
+
+echo "🚀 Starting telemetry traffic generation..."
+echo "Target API: $API_URL"
+echo "Iterations: $ITERATIONS"
+echo ""
+
+for ((i=1; i<=ITERATIONS; i++)); do
+  echo ">>> Request cycle $i"
+
+  curl -s -X POST "$API_URL/books" \
+    -H "Content-Type: application/json" \
+    -d "{\"title\":\"Book $i\",\"author\":\"Author $i\"}" > /dev/null
+
+  curl -s "$API_URL/books" > /dev/null
+
+  curl -s "$API_URL/books/1" > /dev/null
+
+  curl -s -X PATCH "$API_URL/books/1" \
+    -H "Content-Type: application/json" \
+    -d "{\"title\":\"Updated Book $i\"}" > /dev/null
+
+  curl -s -X DELETE "$API_URL/books/1" > /dev/null
+
+  echo "✔ Completed request cycle $i"
+  sleep "$SLEEP_INTERVAL"
+done
+
+echo ""
+echo "🎉 Completed all $ITERATIONS traffic iterations."


### PR DESCRIPTION
In the following article: https://signoz.io/opentelemetry/go/, we have simple 1-2 CRUD requests, which might trouble new folks in understanding how to send traffic in bulk to SigNoz and hence might get the wrong idea of visualization.

This commit contains a script that will hit multiple CRUD requests, generating enough traffic to easily visualize on SigNoz. I am adding the steps on how to run the script in the article.
